### PR TITLE
fix thumbnail url for bazaar app

### DIFF
--- a/Apps/Bazarr/appfile.json
+++ b/Apps/Bazarr/appfile.json
@@ -5,7 +5,7 @@
 	"icon": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bazarr/icon.png",
 	"tagline": "Letter generators for Sonarr and Radarr",
 	"overview": "Bazarr is a companion application to Sonarr and Radarr. It can manage and download subtitles based on your requirements. You define your preferences by TV show or movie and Bazarr takes care of everything for you.",
-	"thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/2FAuth/thumbnail.png",
+	"thumbnail": "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bazarr/thumbnail.png",
 	"screenshots": [
 	"https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bazarr/screenshot-1.png",
 	"https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bazarr/screenshot-2.png",


### PR DESCRIPTION
atm this shows up like this:
![image](https://user-images.githubusercontent.com/43019162/207768630-422dfd24-132d-4617-87de-ba5487ff807e.png)

