### PR TITLE
Added persistent data mapping for Grafana

### DIFF
--- a/Apps/Grafana/appfile.json
+++ b/Apps/Grafana/appfile.json
@@ -49,7 +49,16 @@
 				"description": ""
 			}
 		],
-		"volumes": [],
+		"volumes": [
+			{
+                "container": "/var/lib/grafana",
+                "host": "/DATA/AppData/$AppID/data",
+                "mode": "rw",
+                "allocation": "automatic",
+                "configurable": "no",
+                "description": "Grafana database and plugins directory."
+            }
+		],
 		"devices": [],
 		"constraints": {
 			"min_memory": 64,

--- a/Apps/Grafana/docker-compose.yml
+++ b/Apps/Grafana/docker-compose.yml
@@ -12,11 +12,20 @@ services:
         published: "3003"
         protocol: tcp
     restart: always
+    volumes:
+      - type: bind
+        source: /DATA/AppData/$AppID/data
+        target: /var/lib/grafana
     x-casaos:
       ports:
         - container: "3000"
           description:
             en_us: ""
+      volumes:
+        - container: /var/lib/grafana
+          description:
+            en_us: Grafana database and plugins directory.
+            zh_cn: Grafana 数据库和插件目录
 
 x-casaos:
   architectures:


### PR DESCRIPTION
Added Persistent data mapping for Grafana as shown in [Grafana Docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/)

#49 