### PR TITLE
fix: delete unused interpolation var in Jellyfin

### DIFF
--- a/Apps/Jellyfin/appfile.json
+++ b/Apps/Jellyfin/appfile.json
@@ -59,12 +59,6 @@
                 "value": "$PGID",
                 "configurable": "no",
                 "description": "Run Jellyfin as specified gid."
-            },
-            {
-                "key": "JELLYFIN_PublishedServerUrl",
-                "value": "$APP_IPV4",
-                "configurable": "advanced",
-                "description": "The autodiscovery response domain or IP address."
             }
         ],
         "ports": [

--- a/Apps/Jellyfin/docker-compose.yml
+++ b/Apps/Jellyfin/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - /dev/video11:/dev/video11
       - /dev/video12:/dev/video12
     environment:
-      JELLYFIN_PublishedServerUrl: $APP_IPV4
       PGID: $PGID
       PUID: $PUID
       TZ: $TZ


### PR DESCRIPTION
casaos app management didn't interpolate $APP_IPV4. So It can't be interpolated.

@JohnGuan @tigerinus Please take a look

The Problem:
If didn't delete the interpolation Value. the `app management` will warn the info in every frontend to get `appgrid`