### PR TITLE
Changed Node-Red network mode to host

### DIFF
--- a/Apps/Node-RED/appfile.json
+++ b/Apps/Node-RED/appfile.json
@@ -32,7 +32,7 @@
 		"image": "nodered/node-red:2.2.2-12",
 		"shell": "sh",
 		"privileged": false,
-		"network_model": "bridge",
+		"network_model": "host",
 		"web_ui": {
 			"http": "1880",
 			"path": "/"


### PR DESCRIPTION
Node red does not work well when it is on bridge mode with other tools such as HomeBridge and HomeAssistant. Running it on host mode solves problem. The other alternative is to have both on same network but this one is better since homebridge asks host mode specifically which is one of the main integration which people use with Node-Red.