### PR TITLE
Update docker-compose.yml

### DIFF
--- a/Apps/Node-RED/docker-compose.yml
+++ b/Apps/Node-RED/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       resources:
         reservations:
           memory: 64M
-    network_mode: bridge
+    network_mode: host
     ports:
       - target: 1880
         published: "1880"


### PR DESCRIPTION
Node red does not work well when it is on bridge mode with other tools such as HomeBridge and HomeAssistant. Running it on host mode solves problem. The other alternative is to have both on same network but this one is better since homebridge asks host mode specifically which is one of the main integration which people use with Node-Red. Update Node-Red compose file network_mode