### PR TITLE
replaced deprecated DOCKER_MODS

### DIFF
--- a/Apps/Calibre-web/appfile.json
+++ b/Apps/Calibre-web/appfile.json
@@ -59,7 +59,7 @@
 			},
 			{
 				"key": "DOCKER_MODS",
-				"value": "linuxserver/calibre-web:calibre",
+				"value": "ghcr.io/linuxserver/mods:universal-calibre",
 				"description": "",
 				"configurable": "no"
 			}

--- a/Apps/Calibre-web/docker-compose.yml
+++ b/Apps/Calibre-web/docker-compose.yml
@@ -2,7 +2,7 @@ name: calibre-web
 services:
   calibre-web:
     environment:
-      DOCKER_MODS: linuxserver/calibre-web:calibre
+      DOCKER_MODS: ghcr.io/linuxserver/mods:universal-calibre
       PGID: $PGID
       PUID: $PUID
       TZ: $TZ


### PR DESCRIPTION
```bash
...

* Setting up desktop integration failed with error:

    ********************************************************
    ********************************************************
    *                                                      *
    *                         !!!!                         *
    *   This mod is no longer updated, please switch to    *
    *      ghcr.io/linuxserver/mods:universal-calibre      *
    *                                                      *
    *                                                      *
    ********************************************************
    ********************************************************
...
```

self explanatory, I guess :)