### PR TITLE
Updated Cloudflared image into new image repository

### DIFF
--- a/Apps/Cloudflared/docker-compose.yml
+++ b/Apps/Cloudflared/docker-compose.yml
@@ -1,7 +1,7 @@
 name: cloudflared
 services:
   cloudflared:
-    image: wisdomsky/casaos-cloudflared:2023.7.3
+    image: wisdomsky/cloudflared-web:2023.7.3
     restart: unless-stopped
     network_mode: host
     x-casaos:


### PR DESCRIPTION
Cloudflare docker image has been renamed from [wisdomsky/casaos-cloudflared](https://hub.docker.com/r/wisdomsky/casaos-cloudflared) into [wisdomsky/cloudflared-web](https://hub.docker.com/r/wisdomsky/cloudflared-web).