### PR TITLE
Fix calibre web

### DIFF
--- a/Apps/Calibre-web/docker-compose.yml
+++ b/Apps/Calibre-web/docker-compose.yml
@@ -93,7 +93,7 @@ x-casaos:
     pt_br: Aplicativo da web para navegar, ler e baixar eBooks armazenados em um banco de dados Calibre
     sv_se: Webbapplikation för att bläddra, läsa och ladda ner e-böcker som lagras i en Calibre-databas
     uk_ua: Веб-застосунок для перегляду, читання та завантаження електронних книг, що зберігаються в базі даних Calibre
-  thumbnail: ' https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Calibre-web/thumbnail.png'
+  thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Calibre-web/thumbnail.png
   tips:
     before_install:
       en_us: |

--- a/Apps/Cloudflared/docker-compose.yml
+++ b/Apps/Cloudflared/docker-compose.yml
@@ -1,7 +1,7 @@
 name: cloudflared
 services:
   cloudflared:
-    image: wisdomsky/casaos-cloudflared:2023.7.3
+    image: wisdomsky/cloudflared-web:2023.7.3
     restart: unless-stopped
     network_mode: host
     x-casaos:


### PR DESCRIPTION
Remove leading whitespace in the thumbnail property value in the `docker-compose.yaml` file which causes the `Export ComposeFile` option for Calibre-web in CasaOS to not work.

![image](https://github.com/IceWhaleTech/CasaOS-AppStore/assets/6792172/7438106b-f775-4a4c-bfa0-bb3b8cc1fb1c)

![image](https://github.com/IceWhaleTech/CasaOS-AppStore/assets/6792172/ef3d7979-e859-4b53-9707-cb20a6415bc5)
