### PR TITLE
Update Portainer to 2.19.1

### DIFF
--- a/Apps/Portainer/docker-compose.yml
+++ b/Apps/Portainer/docker-compose.yml
@@ -1,7 +1,7 @@
 name: portainer
 services:
   portainer:
-    image: portainer/portainer-ce:2.18.4
+    image: portainer/portainer-ce:2.19.1
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
See https://github.com/portainer/portainer/releases for 2 recent releases since 2.18.4