### PR TITLE
Update Crafty-4 container to 4.2.0

### DIFF
--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.1.3
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.0
     restart: always
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
Hi there, I'm on the crafty team (`@Boat___`) on the discord. We've been seeing a lot of new people use CasaOS for crafty which is awesome!
We just released the new version `4.2.0` and would love to get it updated on CasaOS. This update is a medium sized update but there should be no breaking changes based on the docker-compose used by y'all. Docker installs have been well tested on our end.

Is making these PRs the best way to keep our app updated on CasaOS in the future?