### PR TITLE
Bump Crafty to 4.2.1

### DIFF
--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.0
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.1
     restart: always
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
Bumping Crafty Controller to 4.2.1.

No breaking changes for CasaOS, just a minor bug fix.