### PR TITLE
update lucky version to 2.5.0

### DIFF
--- a/Apps/Lucky/docker-compose.yml
+++ b/Apps/Lucky/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       resources:
         reservations:
           memory: 64M
-    image: gdy666/lucky:2.4.7
-    restart: unless-stopped
+    image: gdy666/lucky:2.5.0
+    restart: always
     volumes:
       - type: bind
         source: /DATA/AppData/lucky


### PR DESCRIPTION
2023-11-21 v2.5.0
 1. filebrowser: 修复了存储模块已知的 bug，现在可以愉快地使用filebrowser 管理阿里云盘。 新增登录令牌有效期参数设置
 2. Web 文件服务:修复了跨域和短连接设置无效的问题。
 3. Lucky新增登录令牌有效期设置参数和最大连续登录错误次数限制，提高账户安全性。
 4. 增加定时 DNS 可用性检测，新增 自定义DNS 和备用 DNS 设置，提供更稳定的网络连接。
 5. 其他已知 bug 修复。