### PR TITLE
Update docker-compose.yml

### DIFF
--- a/Apps/Transmission/docker-compose.yml
+++ b/Apps/Transmission/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       PEERPORT: "51413"
       PGID: "1000"
       PUID: "1000"
-      TRANSMISSION_WEB_HOME: /transmission-web-control/
       TZ: Europe/London
       USER: casaos
     image: linuxserver/transmission:4.0.4


### PR DESCRIPTION
Fix transmission env problem: 
This image no longer bundles 3rd party Transmission UI packages. You will need to either remove the TRANSMISSION_WEB_HOME environment variable from your container or source a UI package yourself and update the path to match We would advise you to use subfolders under /config to store your UI packages so that they survive upgrades