### PR TITLE
Tweaks to UID, GID, TZ and replace unwritable /path/

### DIFF
--- a/Apps/Lazylibrarian/appfile.json
+++ b/Apps/Lazylibrarian/appfile.json
@@ -39,24 +39,24 @@
 		},
 		"health_check": "",
 		"envs": [
-			{
-				"key": "PUID",
-				"value": "1000",
-				"description": "",
-				"configurable": "no"
-			},
-			{
-				"key": "PGID",
-				"value": "1000",
-				"description": "",
-				"configurable": "no"
-			},
-			{
-				"key": "TZ",
-				"value": "Europe/London",
-				"description": "",
-				"configurable": "no"
-			},
+            {
+                "key": "TZ",
+                "value": "$TZ",
+                "configurable": "no",
+                "description": "TimeZone"
+            },
+            {
+                "key": "PUID",
+                "value": "$PUID",
+                "configurable": "no",
+                "description": "Run LazyLibrarian as specified uid."
+            },
+            {
+                "key": "PGID",
+                "value": "$PGID",
+                "configurable": "no",
+                "description": "Run LazyLibrarian as specified gid."
+            },
 			{
 				"key": "DOCKER_MODS",
 				"value": "linuxserver/calibre-web:calibre|linuxserver/mods:lazylibrarian-ffmpeg",
@@ -80,16 +80,16 @@
 				"host": "/DATA/Downloads",
 				"mode": "rw",
 				"allocation": "automatic",
-				"configurable": "no",
-				"description": ""
+				"configurable": "advanced",
+				"description": "LazyLibrarian downloads directory"
 			},
 			{
 				"container": "/books",
-				"host": "/path/to/data",
+				"host": "/DATA/Media/Books",
 				"mode": "rw",
 				"allocation": "automatic",
-				"configurable": "no",
-				"description": ""
+				"configurable": "advanced",
+				"description": "LazyLibrarian Books directory"
 			},
 			{
 				"container": "/config",
@@ -97,7 +97,7 @@
 				"mode": "rw",
 				"allocation": "automatic",
 				"configurable": "no",
-				"description": ""
+				"description": "LazyLibrarian Config directory"
 			}
 		],
 		"devices": [],

--- a/Apps/Lazylibrarian/docker-compose.yml
+++ b/Apps/Lazylibrarian/docker-compose.yml
@@ -3,9 +3,9 @@ services:
   lazylibrarian:
     environment:
       DOCKER_MODS: linuxserver/calibre-web:calibre|linuxserver/mods:lazylibrarian-ffmpeg
-      PGID: "1000"
-      PUID: "1000"
-      TZ: Europe/London
+      PGID: $PGID
+      PUID: $PUID
+      TZ: $TZ
     image: linuxserver/lazylibrarian:version-0ca9b70c
     deploy:
       resources:
@@ -22,7 +22,7 @@ services:
         source: /DATA/Downloads
         target: /downloads
       - type: bind
-        source: /path/to/data
+        source: /DATA/Media/Books
         target: /books
       - type: bind
         source: /DATA/AppData/lazylibrarian/config
@@ -31,13 +31,13 @@ services:
       envs:
         - container: PUID
           description:
-            en_us: ""
+            en_us: "Run LazyLibrarian as specified UID"
         - container: PGID
           description:
-            en_us: ""
+            en_us: "Run LazyLibrarian as specified GID"
         - container: TZ
           description:
-            en_us: ""
+            en_us: "TimeZone"
         - container: DOCKER_MODS
           description:
             en_us: ""
@@ -49,13 +49,13 @@ services:
       volumes:
         - container: /downloads
           description:
-            en_us: ""
+            en_us:  "LazyLibrarian downloads directory"
         - container: /books
           description:
-            en_us: ""
+            en_us:  "LazyLibrarian Books directory"
         - container: /config
           description:
-            en_us: ""
+            en_us:  "LazyLibrarian config directory"
     container_name: lazylibrarian
 x-casaos:
   architectures:

--- a/Apps/Mylar3/appfile.json
+++ b/Apps/Mylar3/appfile.json
@@ -40,18 +40,24 @@
 		},
 		"health_check": "",
 		"envs": [
-			{
-				"key": "PUID",
-				"value": "1000",
-				"description": "",
-				"configurable": "no"
-			},
-			{
-				"key": "PGID",
-				"value": "1000",
-				"description": "",
-				"configurable": "no"
-			}
+            {
+                "key": "TZ",
+                "value": "$TZ",
+                "configurable": "no",
+                "description": "TimeZone"
+            },
+            {
+                "key": "PUID",
+                "value": "$PUID",
+                "configurable": "no",
+                "description": "Run Mylar3 as specified uid."
+            },
+            {
+                "key": "PGID",
+                "value": "$PGID",
+                "configurable": "no",
+                "description": "Run Mylar3 as specified gid."
+            }
 		],
 		"ports": [
 			{
@@ -74,10 +80,10 @@
 			},
 			{
 				"container": "/comics",
-				"host": "/path/to/comics",
+				"host": "/DATA/Media/Comics",
 				"mode": "rw",
 				"allocation": "automatic",
-				"configurable": "no",
+				"configurable": "advanced",
 				"description": ""
 			},
 			{
@@ -85,7 +91,7 @@
 				"host": "/DATA/Downloads",
 				"mode": "rw",
 				"allocation": "automatic",
-				"configurable": "no",
+				"configurable": "advanced",
 				"description": ""
 			}
 		],

--- a/Apps/Mylar3/docker-compose.yml
+++ b/Apps/Mylar3/docker-compose.yml
@@ -2,8 +2,9 @@ name: mylar3
 services:
   mylar3:
     environment:
-      PGID: "1000"
-      PUID: "1000"
+      PGID: $PGID
+      PUID: $PUID
+      TZ: $TZ
     image: linuxserver/mylar3:0.7.6
     deploy:
       resources:
@@ -20,7 +21,7 @@ services:
         source: /DATA/AppData/mylar3/config
         target: /config
       - type: bind
-        source: /path/to/comics
+        source: /DATA/Media/Comics
         target: /comics
       - type: bind
         source: /DATA/Downloads
@@ -29,10 +30,13 @@ services:
       envs:
         - container: PUID
           description:
-            en_us: ""
+            en_us: "Run Mylar3 as specified uid."
         - container: PGID
           description:
-            en_us: ""
+            en_us: "Run Mylar3 as specified gid."
+        - container: TZ
+          description:
+            en_us: TimeZone
       ports:
         - container: "8090"
           description:
@@ -41,13 +45,13 @@ services:
       volumes:
         - container: /config
           description:
-            en_us: ""
+            en_us: "Mylar3 config directory"
         - container: /comics
           description:
-            en_us: ""
+            en_us: "Mylar3 Comics directory"
         - container: /downloads
           description:
-            en_us: ""
+            en_us: "Mylar3 downloads directory"
     container_name: mylar3
 x-casaos:
   architectures:

--- a/Apps/Readarr/appfile.json
+++ b/Apps/Readarr/appfile.json
@@ -40,24 +40,24 @@
 		},
 		"health_check": "",
 		"envs": [
-			{
-				"key": "PUID",
-				"value": "1000",
-				"description": "",
-				"configurable": "no"
-			},
-			{
-				"key": "PGID",
-				"value": "1000",
-				"description": "",
-				"configurable": "no"
-			},
-			{
-				"key": "TZ",
-				"value": "Europe/London",
-				"description": "",
-				"configurable": "no"
-			}
+            {
+                "key": "TZ",
+                "value": "$TZ",
+                "configurable": "no",
+                "description": "TimeZone"
+            },
+            {
+                "key": "PUID",
+                "value": "$PUID",
+                "configurable": "no",
+                "description": "Run Readarr as specified uid."
+            },
+            {
+                "key": "PGID",
+                "value": "$PGID",
+                "configurable": "no",
+                "description": "Run Readarr as specified gid."
+            }
 		],
 		"ports": [
 			{
@@ -72,27 +72,27 @@
 		"volumes": [
 			{
 				"container": "/config",
-				"host": "/DATA/AppData/readarr/config",
+				"host": "/DATA/AppData/$AppID/config",
 				"mode": "rw",
 				"allocation": "automatic",
 				"configurable": "no",
-				"description": ""
+				"description": "Readarr config directory"
 			},
 			{
 				"container": "/books",
-				"host": "/path/to/books",
+				"host": "/DATA/Media/Books",
 				"mode": "rw",
 				"allocation": "automatic",
-				"configurable": "no",
-				"description": ""
+				"configurable": "advanced",
+				"description": "Readarr books directory"
 			},
 			{
 				"container": "/downloads",
 				"host": "/DATA/Downloads",
 				"mode": "rw",
 				"allocation": "automatic",
-				"configurable": "no",
-				"description": ""
+				"configurable": "advanced",
+				"description": "Readarr downloads directory"
 			}
 		],
 		"devices": [],

--- a/Apps/Readarr/docker-compose.yml
+++ b/Apps/Readarr/docker-compose.yml
@@ -2,9 +2,9 @@ name: readarr
 services:
   readarr:
     environment:
-      PGID: "1000"
-      PUID: "1000"
-      TZ: Europe/London
+      PGID: $PGID
+      PUID: $PUID
+      TZ: $TZ
     image: linuxserver/readarr:0.3.10-develop
     deploy:
       resources:
@@ -22,7 +22,7 @@ services:
         target: /config
         
       - type: bind
-        source: /DATA/AppData/$AppID/books
+        source: /DATA/Media/Books
         target: /books
       - type: bind
         source: /DATA/Downloads
@@ -31,13 +31,13 @@ services:
       envs:
         - container: PUID
           description:
-            en_us: ""
+            en_us: "Run Readarr as specified UID"
         - container: PGID
           description:
-            en_us: ""
+            en_us: "Run Readarr as specified GID"
         - container: TZ
           description:
-            en_us: ""
+            en_us: "Timezon"
       ports:
         - container: "8787"
           description:
@@ -46,13 +46,13 @@ services:
       volumes:
         - container: /config
           description:
-            en_us: ""
+            en_us: "Readarr config directory"
         - container: /books
           description:
-            en_us: ""
+            en_us: "Readarr books directory"
         - container: /downloads
           description:
-            en_us: ""
+            en_us: "Readarr downloads directory"
     container_name: readarr
 x-casaos:
   architectures:


### PR DESCRIPTION
Update appfile and docker compose for LazyLibrarian, Mylar3 and Readarr to use consistent conventions for UID, GID and TZ, as well as replacing the unwritable /path/ location, and make the config of these paths available in the GUI
