### PR TITLE
Update lucky version to 2.6.1

### DIFF
--- a/Apps/Lucky/docker-compose.yml
+++ b/Apps/Lucky/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       resources:
         reservations:
           memory: 64M
-    image: gdy666/lucky:2.6.1
+    image: gdy666/lucky:2.6.2
     restart: unless-stopped
     volumes:
       - type: bind

--- a/Apps/Lucky/docker-compose.yml
+++ b/Apps/Lucky/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       resources:
         reservations:
           memory: 64M
-    image: gdy666/lucky:2.5.3
+    image: gdy666/lucky:2.6.1
     restart: unless-stopped
     volumes:
       - type: bind


### PR DESCRIPTION
1. 修复了历史记录中未显示DDNS Webhook的bug。
2. 将DDNS Webhook和全局Webhook的历史记录分开。
3. 修复了禁用STUN模块后再启用时规则列表不显示的bug。
4. STUN功能增加了指定UPnP网关参数。
5. 将STUN Webhook和全局Webhook的历史记录分开。
6. 修复了调用OpenAPI时崩溃的bug。
7. 在DDNS和ACME服务商中添加了FreeMyIP