### PR TITLE
Update Crafty Controller to 4.2.2, fix missing screenshots

### DIFF
--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -106,6 +106,14 @@ x-casaos:
     es_es: Crafty es un panel de control de Minecraft de código abierto creado con Tornado y AdminLTE, que incluye programación de servidores, una consola interactiva y la capacidad de ejecutar casi cualquier tipo de servidor de Minecraft.
   developer: Crafty Team
   icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/icon.png
+  screenshot_link:
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-1.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-2.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-3.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-4.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-5.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-6.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-7.png
   tagline:
     en_us: Take control of your Minecraft servers.
     es_es: Toma el control de tus servidores de Minecraft.

--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.2
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.1
     restart: always
     environment:
       - TZ=Etc/UTC

--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.1
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.2
     restart: always
     environment:
       - TZ=Etc/UTC
@@ -116,79 +116,67 @@ x-casaos:
 
         | اسم المستخدم | كلمة المرور |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       de_de: |
         Standardkonto
-
         | Benutzername | Passwort |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       en_us: |
         Default Account
-
         | Username | Password |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       es_es: |
         Cuenta predeterminada
-
         | Nombre de usuario | Contraseña |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       fr_fr: |
         Compte par défaut
-
         | Nom d'utilisateur | Mot de passe |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       hu_hu: |
         Alapértelmezett fiók
-
         | Felhasználónév | Jelszó |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       it_it: |
         Account predefinito
-
         | Nome utente | Password |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       pl_pl: |
         Konto domyślne
-
         | Nazwa użytkownika | Hasło |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       pt_br: |
         Conta padrão
-
         | Nome de usuário | Senha |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       ru_ru: |
         Учетная запись по умолчанию
-
         | Имя пользователя | Пароль |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       sv_se: |
         Standardkonto
-
         | Användarnamn | Lösenord |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       uk_ua: |
         Обліковий запис за замовчуванням
-
         | Ім'я користувача | Пароль |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
       zh_cn: |
         默认账号
-
         | 用户名 | 密码 |
         |----------|----------|
-        | `admin`    | `crafty` |
+        | `admin`    | `app/config/default-creds.txt` |
   title:
     en_us: Crafty
   index: /panel

--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.1
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.2
     restart: always
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
Hello,

We saw y'all needed to rollback Crafty for some text display issues. I see that this has been resolved in a recent update of CasaOS.
I validated this version of Crafty against CasaOS v0.4.6 on 2024-01-23.

Screenshot of testing:
![firefox_2024-01-23_15-53-49](https://github.com/IceWhaleTech/CasaOS-AppStore/assets/22280421/01998490-9f50-4ffb-b0b6-08440a1b937c)

Additionally updated the screenshot links to also appear the yml file so that screenshots correctly appear in the app store.

PR was waiting for issue 1559 from the main CasaOS repository.

Best,
Boat from the Crafty Team