### PR TITLE
Bump Crafty to 4.2.3

### DIFF
--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.2
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.3
     restart: always
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
Bumps Crafty to new version 4.2.3

Security update for Crafty, resolves CVE-2024-1064

No breaking changes for CasaOS.