### PR TITLE
fix: upgrade version of navidrome to resolve ARM Docker image issue

### DIFF
--- a/Apps/Navidrome/docker-compose.yml
+++ b/Apps/Navidrome/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: deluan/navidrome:0.50.1
     labels:
       icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Navidrome/icon.png
-    restart: always
+    restart: unless-stopped
     ports:
       - target: 4533
         published: "4533"
@@ -27,7 +27,7 @@ services:
       ND_SESSIONTIMEOUT: 24h
       ND_BASEURL: ""
       TZ: $TZ
-    network_mode: host
+    network_mode: bridge
     privileged: false
     x-casaos:
       envs:

--- a/Apps/Navidrome/docker-compose.yml
+++ b/Apps/Navidrome/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       resources:
         reservations:
           memory: 1024M
-    image: deluan/navidrome:0.50.0
+    image: deluan/navidrome:0.50.1
     labels:
       icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Navidrome/icon.png
     restart: always


### PR DESCRIPTION
I had a problem installing on Raspberry Pi 4. After checking, I found that version 0.50.0 had a problem with the image when pushing it to Docker hub, and Navidrome fixed it in version 0.50.1.

Source: https://github.com/navidrome/navidrome/releases/tag/v0.50.1