### PR TITLE
Update Crafty Controller to 4.3.0

### DIFF
--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,11 +5,7 @@ version: "3"
 services:
   crafty:
     container_name: crafty-container
-<<<<<<< HEAD
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.2.3
-=======
     image: registry.gitlab.com/crafty-controller/crafty-4:4.3.0
->>>>>>> 36637c03bcf835f17f8ae78302e248154bbbd0d1
     restart: always
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
Updating the Crafty controller app to 4.3.0.

No breaking changes for how the docker container for Crafty operates. Major version change because it is impossible to downgrade from 4.3.0.

Tested in CasaOS without issue 2024-03-08
 
 Quotes changed per YML linting.