### PR TITLE
bump lucky to v2.8.1

### DIFF
--- a/Apps/Lucky/docker-compose.yml
+++ b/Apps/Lucky/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       resources:
         reservations:
           memory: 64M
-    image: gdy666/lucky:2.7.1
+    image: gdy666/lucky:2.8.1
     restart: unless-stopped
     volumes:
       - type: bind


### PR DESCRIPTION
优化：
1. 安全入口修改后三秒即生效，无须重启程序。
2. 简化了ZeroSSL的使用流程，无需手动填写EAB信息，使ZeroSSL的使用变得和Let's Encrypt一样简单。
3. 2FA输入六位纯数字后自动登录。 修复：
1. 修复了在使用反向代理nginx参数proxy_hide_header时无效的bug。
2. 修复了web服务前端域名大小写和中文识别的问题。
3. 修复了前端回车登录无效的bug。
4. 修复了DDNS 模块框架已知的bug。
5. 修复了反代群晖webdav修改移动文件出错的bug。 新增：
1. Web服务现在默认支持HTTP/2。
2. Web服务新增了HTTP/3支持开关，并且可以针对单独的子规则禁用HTTP/3