### PR TITLE
Bump Crafty to 4.3.2

### DIFF
--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3"
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.3.0
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.3.2
     restart: always
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
Tested on CasaOS on 2024-04-06

Upgrading to Latest version of Crafty Controller. All upgrades are internal to Crafty, no breaking changes or new ports for CasaOS. Migrations from 4.3.0 are tested and working.

Includes:
Bug fixes and upgrades for Crafty for 4.3.1 and 4.3.2
Java 21 LTS for future release of MC
Resolved issue related to external API dependency on serverjars.com

Screenshots from test on 2024-04-06:
![2024-04-06_19-19-29](https://github.com/IceWhaleTech/CasaOS-AppStore/assets/22280421/48bd294b-20f6-4d1f-a7fa-a3e6c61500c8)
![2024-04-06_19-23-08](https://github.com/IceWhaleTech/CasaOS-AppStore/assets/22280421/1cb2d87c-a83d-4f1e-bdaa-4f3c0f8aaf5c)
