### PR TITLE
Update Home Assistant to the latest version

### DIFF
--- a/Apps/HomeAssistant/appfile.json
+++ b/Apps/HomeAssistant/appfile.json
@@ -30,7 +30,7 @@
     "support": "https://discord.gg/knqAbbBbeX",
     "website": "https://www.casaos.io",
     "container": {
-        "image": "ghcr.io/home-assistant/home-assistant:stable",
+        "image": "homeassistant/home-assistant:2024.5",
         "shell": "bash",
         "privileged": false,
         "network_model": "host",

--- a/Apps/HomeAssistant/appfile.json
+++ b/Apps/HomeAssistant/appfile.json
@@ -30,7 +30,7 @@
     "support": "https://discord.gg/knqAbbBbeX",
     "website": "https://www.casaos.io",
     "container": {
-        "image": "linuxserver/homeassistant:latest",
+        "image": "ghcr.io/home-assistant/home-assistant:stable",
         "shell": "bash",
         "privileged": false,
         "network_model": "host",
@@ -91,5 +91,5 @@
         "latest_updates": "",
         "url": ""
     },
-    "latest_update_date": "1640591843"
+    "latest_update_date": "1715085739765"
 }

--- a/Apps/HomeAssistant/docker-compose.yml
+++ b/Apps/HomeAssistant/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       PGID: $PGID
       PUID: $PUID
       TZ: $TZ
-    image: linuxserver/homeassistant:2023.11.3
+    image: ghcr.io/home-assistant/home-assistant:stable
     deploy:
       resources:
         reservations:

--- a/Apps/HomeAssistant/docker-compose.yml
+++ b/Apps/HomeAssistant/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       PGID: $PGID
       PUID: $PUID
       TZ: $TZ
-    image: ghcr.io/home-assistant/home-assistant:stable
+    image: homeassistant/home-assistant:2024.5
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
Update Home Assistant to the latest version and image location

```
New:
Docker Image: homeassistant/home-assistant
Version: 2024.5
```

Closes #471
Closes IceWhaleTech/CasaOS#1814