### PR TITLE
Bump Crafty Controller to 4.4.0

### DIFF
--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3"
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.3.2
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.4.2
     restart: always
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
Bumping Crafty Controller to version 4.4.0.

Update primarily changes a Crafty controller dependency, Serverjars, to updated Big Bucket. No major changes affecting integration with CasaOS.

Full changelog for update can be found [here](https://gitlab.com/crafty-controller/crafty-4/-/blob/master/CHANGELOG.md?ref_type=heads).

Tested on CasaOS on 2024-05-11. No issues found during test. See below screenshots from test:
![Arc_2024-05-11_18-23-54](https://github.com/IceWhaleTech/CasaOS-AppStore/assets/22280421/2550c2ec-13c3-499f-9e51-dcce9d130527)
![Arc_2024-05-11_18-24-07](https://github.com/IceWhaleTech/CasaOS-AppStore/assets/22280421/ec566420-3cb8-42c3-9b89-20cebac129dd)
![2024-05-11_18-22-01](https://github.com/IceWhaleTech/CasaOS-AppStore/assets/22280421/020ce229-d347-4c46-95da-07b6023619d3)
