### PR TITLE
Fix Crafty 4.4.0 from bad 4.4.2 tag

### DIFF
--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3"
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.4.2
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.4.0
     restart: always
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
Fixing PR: https://github.com/IceWhaleTech/CasaOS-AppStore/pull/476

I accidentally submitted the previous PR to `4.4.2` when the new version of Crafty is `4.4.0`. Small typo, this error is mine, I apologize.

All testing was done on Crafty 4.4.0, no changes just fixing a typo.