### PR TITLE
Update nginxproxymanager to version 2.11.2

### DIFF
--- a/Apps/NginxProxyManager/docker-compose.yml
+++ b/Apps/NginxProxyManager/docker-compose.yml
@@ -1,7 +1,7 @@
 name: nginxproxymanager
 services:
   nginxproxymanager:
-    image: jc21/nginx-proxy-manager:2.11.1
+    image: jc21/nginx-proxy-manager:2.11.2
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
Update includes latest fixes as of https://github.com/NginxProxyManager/nginx-proxy-manager/releases/tag/v2.11.2