### PR TITLE
Bump MySpeed to 1.0.9

### DIFF
--- a/Apps/MySpeed/docker-compose.yml
+++ b/Apps/MySpeed/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       resources:
         limits:
           memory: 256M
-    image: germannewsmaker/myspeed:1.0.8
+    image: germannewsmaker/myspeed:1.0.9
     ports:
       - target: 5216
         published: "5216"


### PR DESCRIPTION
I've updated MySpeed to the newest version `1.0.9`. I have tested the new version with the latest casaos version and found no problems.

Full changelog: https://github.com/gnmyt/myspeed/releases/tag/v1.0.9