### PR TITLE
Bump Crafty to 4.4.3 and remove HTTP port

### DIFF
--- a/Apps/Crafty/appfile.json
+++ b/Apps/Crafty/appfile.json
@@ -51,14 +51,6 @@
         ],
         "ports": [
             {
-                "container": "8000",
-                "host": "8110",
-                "type": "tcp",
-                "allocation": "preferred",
-                "configurable": "advanced",
-                "description": "WebUI HTTP Port"
-            },
-            {
                 "container": "19132",
                 "host": "19132",
                 "type": "udp",

--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,12 +5,11 @@ version: "3"
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.4.0
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.4.3
     restart: always
     environment:
       - TZ=Etc/UTC
     ports:
-      - "8110:8000" # HTTP
       - "8111:8443" # HTTPS
       - "8112:8123" # DYNMAP
       - "19132:19132/udp" # BEDROCK
@@ -24,12 +23,6 @@ services:
 
     x-casaos:
       ports:
-        - container: "8000"
-          description:
-            en_us: WebUI HTTP Port
-            zh_cn: WebUI HTTP端口
-          protocol: tcp
-
         - container: "19132"
           description:
             en_us: Minecraft Bedrock listening Port (UDP)


### PR DESCRIPTION
Bumping Crafty controller to 4.4.3 latest stable version.

No new feature that conflict with CasaOS install.

HTTP handler removed from Crafty, port 8110/8000 HTTP removed from CasaOS config.

Working install config on CasaOS:

![Arc_2024-08-14_19-18-39](https://github.com/user-attachments/assets/f3baebc8-b5ff-4047-8f40-85ac3909502d)
