### PR TITLE
chore: Bump Syncthing version to 1.27.12

### DIFF
--- a/Apps/Syncthing/docker-compose.yml
+++ b/Apps/Syncthing/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       PGID: $PGID
       PUID: $PUID
       TZ: $TZ
-    image: linuxserver/syncthing:1.27.6
+    image: linuxserver/syncthing:1.27.12
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
[Syncthing v1.27.12](https://github.com/syncthing/syncthing/releases/tag/v1.27.12) is released. Bump to this version.