### PR TITLE
chore: Bump Grafana version to 11.1.5

### DIFF
--- a/Apps/Grafana/docker-compose.yml
+++ b/Apps/Grafana/docker-compose.yml
@@ -1,7 +1,7 @@
 name: grafana
 services:
   grafana:
-    image: grafana/grafana:10.2.2
+    image: grafana/grafana:11.1.5
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
[Grafana v11.1.5](https://github.com/grafana/grafana/releases/tag/v11.1.5) is released. Bump to this version.