### PR TITLE
Bump Crafty to 4.4.4

### DIFF
--- a/Apps/Crafty/appfile.json
+++ b/Apps/Crafty/appfile.json
@@ -38,8 +38,8 @@
         "privileged": false,
         "network_model": "bridge",
         "web_ui": {
-            "http": "8110",
-            "path": "/panel"
+            "http": "8111",
+            "path": "/"
         },
         "envs": [
             {
@@ -50,14 +50,6 @@
             }
         ],
         "ports": [
-            {
-                "container": "8000",
-                "host": "8110",
-                "type": "tcp",
-                "allocation": "preferred",
-                "configurable": "advanced",
-                "description": "WebUI HTTP Port"
-            },
             {
                 "container": "19132",
                 "host": "19132",

--- a/Apps/Crafty/docker-compose.yml
+++ b/Apps/Crafty/docker-compose.yml
@@ -5,12 +5,11 @@ version: "3"
 services:
   crafty:
     container_name: crafty-container
-    image: registry.gitlab.com/crafty-controller/crafty-4:4.4.0
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.4.4
     restart: always
     environment:
       - TZ=Etc/UTC
     ports:
-      - "8110:8000" # HTTP
       - "8111:8443" # HTTPS
       - "8112:8123" # DYNMAP
       - "19132:19132/udp" # BEDROCK
@@ -24,12 +23,6 @@ services:
 
     x-casaos:
       ports:
-        - container: "8000"
-          description:
-            en_us: WebUI HTTP Port
-            zh_cn: WebUI HTTP端口
-          protocol: tcp
-
         - container: "19132"
           description:
             en_us: Minecraft Bedrock listening Port (UDP)


### PR DESCRIPTION
Changes:
- Bump Crafty from 4.4.0 to 4.4.4
- Removed HTTP port. Port is no longer used by Crafty and redundant.
- Updated panel path from `/panel` to `/`. `/panel` is not a real path in Crafty. This was added by the initial adapter.
- Moved port in `appfile.json` to `8111`.

Tested in local instance of Crafty, see screenshots.
![firefox_2024-10-23_08-34-42](https://github.com/user-attachments/assets/260bffc4-99ba-4111-a357-a9c02ad77ed4)
![firefox_2024-10-23_08-34-15](https://github.com/user-attachments/assets/20fe7137-1124-4d60-8c81-5c664c0ecc56)
