### PR TITLE
chore: Bump Gitea version to 1.22.4

### DIFF
--- a/Apps/Gitea/docker-compose.yml
+++ b/Apps/Gitea/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     environment:
       USER_GID: "1000"
       USER_UID: "1000"
-    image: gitea/gitea:1.22.2
+    image: gitea/gitea:1.22.4
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
[Gitea v1.22.4](https://github.com/go-gitea/gitea/releases/tag/v1.22.4) is released. Bump to this version.