### PR TITLE
Gopeed Version bump

### DIFF
--- a/Apps/Gopeed/docker-compose.yml
+++ b/Apps/Gopeed/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       resources:
         limits:
           memory: 256M
-    image: liwei2633/gopeed:v1.5.7
+    image: liwei2633/gopeed:v1.6.6
     ports:
       - target: 9999
         published: "9999"


### PR DESCRIPTION
version bumped Gopeed current version is too old

i have tested 1.6.6V and it seems to work well