### PR TITLE
chore: bump alby app version

### DIFF
--- a/Apps/AlbyHub/docker-compose.yml
+++ b/Apps/AlbyHub/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       LOG_EVENTS: true
     command: []
     container_name: albyhub
-    image: ghcr.io/getalby/hub:v1.12.0
+    image: ghcr.io/getalby/hub:v1.13.0
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
New version released: https://getalby.com/update/hub?version=v1.13.0