### PR TITLE
Fix configuration file format errors in Alist-Sync

### DIFF
--- a/Apps/Alist-Sync/docker-compose.yml
+++ b/Apps/Alist-Sync/docker-compose.yml
@@ -26,38 +26,35 @@ services:
           description:
             en_us: Directory where the alist-sync application stores its data.
             zh_cn: alist-sync 配置目录
-      architectures:
-        - 386
-        - amd64
-        - arm/v6
-        - arm/v7
-        - arm64
-        - ppc64le
-        - s390x
-      main: alist-sync
-      author: xjxjin
-      category: Cloud
-      description:
-        en_us: |
-          Alist-Sync is a storage synchronization tool based on the Web interface. It can achieve data synchronization and mutual backup among multiple network disks, and also has practical functions such as multi-task management, scheduled synchronization and difference handling.
-        zh_cn: |
-          Alist-Sync 是一款基于 Web 界面的存储同步工具，它能够在多个网盘之间实现数据同步以及相互备份，并且具备多任务管理、定时同步、差异处理等实用功能。
-      developer: xjxjin
-      icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/icon.png
-      screenshot_link:
-        - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-1.png
-        - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-2.png
-        - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-3.png
-        - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-4.png
-      tagline:
-        en_us: An Alist storage synchronization tool based on the Web interface.
-        zh_cn: 一个基于 Web 界面的 Alist 存储同步工具。
+x-casaos:
+  architectures:
+    - amd64
+    - arm
+    - arm64
+  main: alist-sync
+  author: xjxjin
+  category: Cloud
+  description:
+    en_us: |
+      Alist-Sync is a storage synchronization tool based on the Web interface. It can achieve data synchronization and mutual backup among multiple network disks, and also has practical functions such as multi-task management, scheduled synchronization and difference handling.
+    zh_cn: |
+      Alist-Sync 是一款基于 Web 界面的存储同步工具，它能够在多个网盘之间实现数据同步以及相互备份，并且具备多任务管理、定时同步、差异处理等实用功能。
+  developer: xjxjin
+  icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/icon.png
+  screenshot_link:
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-1.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-2.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-3.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-4.png
+  tagline:
+    en_us: An Alist storage synchronization tool based on the Web interface.
+    zh_cn: 一个基于 Web 界面的 Alist 存储同步工具。
 
-      thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/thumbnail.png
-      title:
-        en_us: Alist-Sync
-      tips:
-        before_install:
-          en_us: The default login password is admin/admin.
-          zh_cn: 默认登录密码 admin/admin。
-      port_map: "52441"
+  thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/thumbnail.png
+  title:
+    en_us: Alist-Sync
+  tips:
+    before_install:
+      en_us: The default login password is admin/admin.
+      zh_cn: 默认登录密码 admin/admin。
+  port_map: "52441"


### PR DESCRIPTION
Unable to display applications correctly in the app store, fix the configuration file format error of Alist Sync