### PR TITLE
AlbyHub v1.15.0

### DIFF
--- a/Apps/AlbyHub/docker-compose.yml
+++ b/Apps/AlbyHub/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       LOG_EVENTS: true
     command: []
     container_name: albyhub
-    image: ghcr.io/getalby/hub:v1.14.3
+    image: ghcr.io/getalby/hub:v1.15.0
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
Updates to Alby Hub v1.15.0

Which contains an important bug fix for a relay connection issue.
In some cases a relay connection fails for some app connections which is then not recovered which causes the app to fail.
