### PR TITLE
chore: Bump Gitea version to 1.24.6

### DIFF
--- a/Apps/Gitea/docker-compose.yml
+++ b/Apps/Gitea/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     environment:
       USER_GID: "1000"
       USER_UID: "1000"
-    image: gitea/gitea:1.24.2
+    image: gitea/gitea:1.24.6
     deploy:
       resources:
         reservations:

--- a/Apps/Gitea/docker-compose.yml
+++ b/Apps/Gitea/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     environment:
       USER_GID: "1000"
       USER_UID: "1000"
-    image: gitea/gitea:1.22.4
+    image: gitea/gitea:1.24.2
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
[Gitea v1.24.6](https://github.com/go-gitea/gitea/releases/tag/v1.24.6) is released. Bump to this version.