### PR TITLE
chore: Bump Gateway-go version to 2.0.10

### DIFF
--- a/Apps/Gateway-go/docker-compose.yml
+++ b/Apps/Gateway-go/docker-compose.yml
@@ -1,7 +1,7 @@
 name: gateway-go
 services:
   gateway-go:
-    image: openiothub/gateway-go:v0.3.22
+    image: openiothub/gateway-go:v2.0.10
     network_mode: host
     deploy:
       resources:


### PR DESCRIPTION
New gateway-go release support ipv6 p2p transport