### PR TITLE
Remove 'immich-v2' from featured apps

### DIFF
--- a/featured-apps.json
+++ b/featured-apps.json
@@ -30,7 +30,6 @@
     { "appid": "navidrome" },
     { "appid": "audiobookshelf" },
     { "appid": "lyrionmusicserver" },
-    { "appid": "immich-v2" },
     { "appid": "photoprism" },
     { "appid": "retroarch" },
     { "appid": "romm" },


### PR DESCRIPTION
Removed 'immich-v2' from the featured apps list.