### PR TITLE
Update downtify to 1.1.1

### DIFF
--- a/Apps/Downtify/docker-compose.yml
+++ b/Apps/Downtify/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       PGID: $PGID
       PUID: $PUID
       TZ: $TZ
-    image: ghcr.io/henriquesebastiao/downtify:1.1.0@sha256:b8c88de2677d00848d6e9af39bfdd67fc7e2bf02012b136aeda4da80e0a3cf3d
+    image: ghcr.io/henriquesebastiao/downtify:1.1.1@sha256:6799338c2369d18941d2e4b9cbc99c762a694e3bce5b769678a3f4edd0ba8b6c
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
This pull request updates Downtify to version `1.1.1`.

The new version fixes a critical bug that caused all downloads to fail. This error was caused by the lack of an updated `yt-dlp` library.