### PR TITLE
Update docker-compose.yml for docker filebrowser/filebrowser:v2.49.0

### DIFF
--- a/Apps/FileBrowser/docker-compose.yml
+++ b/Apps/FileBrowser/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - type: bind
         source: /DATA/AppData/$AppID/db
-        target: /db
+        target: /database
       - type: bind
         source: /DATA
         target: /srv


### PR DESCRIPTION
Docker Image is expecting the database volume target to be /database
Because this is incorrect, any changes from the ZimaOSv1.5.4 gui to the container will remove the container and re-run.
The previous changes will not be saved due to the volume pointing to the wrong spot.

Original Error from:

```
$ sudo docker logs filebrowser 

2026/02/14 10:23:09 Using config file: /config/settings.json                  
2026/02/14 10:23:09 WARNING: filebrowser.db can't be found. Initialing in /dat
abase/    
2026/02/14 10:23:09 Using database: /database/filebrowser.db                  
2026/02/14 10:23:09 Performing quick setup                                    
2026/02/14 10:23:09 User 'admin' initialized with randomly generated password
```

Testing confirmed this by:
1) removing the filebrowser app by "Uninstall"
2) deleting the leftover database with `rm /AppData/filebrowser/db/filebrowser.db`
3) installing the container with custom settings, setting the correct path as indicated.
4) read docker logs and retrieved the random password. 
5) logged in and changed password.
6) edited the TZ variable in the GUI and saved. This triggered the removal of the container.  
7) logged back in with the new password, confirming the database saved correctly and the fix works. 