### PR TITLE
Add DeviceShelf 1.9.6

### DIFF
--- a/Apps/DeviceShelf/docker-compose.yml
+++ b/Apps/DeviceShelf/docker-compose.yml
@@ -1,0 +1,79 @@
+name: deviceshelf
+services:
+  deviceshelf:
+    image: ghcr.io/wealthwallet/deviceshelf-server:1.7.7
+    container_name: deviceshelf
+    # Layer-2 discovery (ARP, mDNS, passive DHCP) only works inside the host's
+    # network namespace. On a bridge the scanner would inventory Docker's own
+    # subnet and report an almost empty LAN, which looks like a broken app
+    # rather than a packaging choice — hence host, and hence no `ports:`.
+    network_mode: host
+    cap_add:
+      - NET_RAW
+      - NET_BIND_SERVICE
+    environment:
+      # Left empty on purpose: the server mints a random token on first start
+      # and writes it to /DATA/AppData/deviceshelf/data/DeviceShelf/api-token,
+      # which CasaOS users can open in the Files app. Setting a fixed token here
+      # would put a credential in a public app-store manifest.
+      DEVICESHELF_API_TOKEN: ""
+      DEVICESHELF_API_PORT: "8088"
+      DEVICESHELF_INTERVAL: "5m"
+      DEVICESHELF_PORTSCAN: "true"
+      TZ: $TZ
+    restart: unless-stopped
+    # A named volume, not a bind mount under /DATA/AppData. The image runs as
+    # uid 10001 and CasaOS creates AppData directories as root, so a bind mount
+    # leaves the server unable to create /data/DeviceShelf: it logs "permission
+    # denied" and restart-loops. Verified on Ubuntu 24.04 — bind mount crash
+    # loop, named volume healthy, because Docker seeds a fresh named volume from
+    # the image and keeps its ownership.
+    volumes:
+      - deviceshelf-data:/data
+    x-casaos:
+      volumes:
+        - container: /data
+          description:
+            en_US: Device inventory, history, settings and the licence.
+volumes:
+  deviceshelf-data:
+x-casaos:
+  id: app.deviceshelf.server
+  architectures:
+    - amd64
+    - arm64
+  main: deviceshelf
+  author: Christof Müller
+  developer: Christof Müller
+  category: Network
+  description:
+    en_US: |
+      DeviceShelf scans your LAN and keeps an inventory of what is on it: vendor,
+      hostname, operating system, device type, open ports and the services behind
+      them. Everything runs on this machine — no account, and nothing about your
+      network leaves it unless you switch on one of the optional lookups.
+
+      It alerts on new devices, on devices dropping offline and on newly opened
+      ports through ntfy, Gotify, a webhook or any Apprise target, with a digest
+      mode so a rebooting switch does not produce forty notifications. Favourites
+      are published to Home Assistant over MQTT discovery as native entities.
+
+      Paid software: 59 EUR once, no subscription, 7-day trial without a card.
+      The same licence covers the desktop and mobile apps.
+  tagline:
+    en_US: See every device on your network, what it is, and what it has open
+  title:
+    en_US: DeviceShelf
+  icon: https://deviceshelf.app/assets/img/icon.png
+  thumbnail: https://deviceshelf.app/assets/img/icon.png
+  index: /
+  port_map: "8088"
+  scheme: http
+  tips:
+    before_install:
+      en_US: |
+        Host networking is required, so the dashboard answers on port 8088 of this
+        machine. The server mints an access token on first start. Read it from the
+        CasaOS terminal with:
+          docker exec deviceshelf deviceshelf-server -token
+  webui_port: 8088

--- a/Apps/DeviceShelf/docker-compose.yml
+++ b/Apps/DeviceShelf/docker-compose.yml
@@ -1,7 +1,7 @@
 name: deviceshelf
 services:
   deviceshelf:
-    image: ghcr.io/wealthwallet/deviceshelf-server:1.9.4
+    image: ghcr.io/wealthwallet/deviceshelf-server:1.9.5
     container_name: deviceshelf
     # Layer-2 discovery (ARP, mDNS, passive DHCP) only works inside the host's
     # network namespace. On a bridge the scanner would inventory Docker's own

--- a/Apps/DeviceShelf/docker-compose.yml
+++ b/Apps/DeviceShelf/docker-compose.yml
@@ -1,7 +1,7 @@
 name: deviceshelf
 services:
   deviceshelf:
-    image: ghcr.io/wealthwallet/deviceshelf-server:1.9.5
+    image: ghcr.io/wealthwallet/deviceshelf-server:1.9.6
     container_name: deviceshelf
     # Layer-2 discovery (ARP, mDNS, passive DHCP) only works inside the host's
     # network namespace. On a bridge the scanner would inventory Docker's own

--- a/Apps/DeviceShelf/docker-compose.yml
+++ b/Apps/DeviceShelf/docker-compose.yml
@@ -1,7 +1,7 @@
 name: deviceshelf
 services:
   deviceshelf:
-    image: ghcr.io/wealthwallet/deviceshelf-server:1.7.7
+    image: ghcr.io/wealthwallet/deviceshelf-server:1.9.4
     container_name: deviceshelf
     # Layer-2 discovery (ARP, mDNS, passive DHCP) only works inside the host's
     # network namespace. On a bridge the scanner would inventory Docker's own

--- a/Apps/DeviceShelf/docker-compose.yml
+++ b/Apps/DeviceShelf/docker-compose.yml
@@ -1,7 +1,7 @@
 name: deviceshelf
 services:
   deviceshelf:
-    image: ghcr.io/wealthwallet/deviceshelf-server:1.9.30
+    image: ghcr.io/wealthwallet/deviceshelf-server:1.9.32
     container_name: deviceshelf
     # Layer-2 discovery (ARP, mDNS, passive DHCP) only works inside the host's
     # network namespace. On a bridge the scanner would inventory Docker's own

--- a/Apps/DeviceShelf/docker-compose.yml
+++ b/Apps/DeviceShelf/docker-compose.yml
@@ -1,7 +1,7 @@
 name: deviceshelf
 services:
   deviceshelf:
-    image: ghcr.io/wealthwallet/deviceshelf-server:1.9.6
+    image: ghcr.io/wealthwallet/deviceshelf-server:1.9.30
     container_name: deviceshelf
     # Layer-2 discovery (ARP, mDNS, passive DHCP) only works inside the host's
     # network namespace. On a bridge the scanner would inventory Docker's own


### PR DESCRIPTION
Adds **DeviceShelf Server**, a local network scanner and device inventory: it lists what is on the LAN with vendor, hostname, OS, device type, open ports and the services behind them, alerts on new devices / devices dropping offline / newly opened ports, and publishes favourites to Home Assistant over MQTT discovery.

Site: https://deviceshelf.app/server · Image: `ghcr.io/wealthwallet/deviceshelf-server` (amd64 + arm64)

Two packaging choices worth a reviewer's attention, both driven by testing rather than preference:

**`network_mode: host`.** Layer-2 discovery (ARP, mDNS, passive DHCP) only works inside the host's network namespace. On a bridge the scanner inventories Docker's own subnet and reports an almost empty LAN, which reads as a broken app. Tested on Ubuntu 24.04 (arm64): with host networking it found 39 devices on the real LAN with vendor, hostname and type. `NET_RAW` and `NET_BIND_SERVICE` are needed for the ARP scan and for passive DHCP fingerprinting on UDP/67; the process itself runs as an unprivileged uid.

**A named volume instead of a bind mount under `/DATA/AppData`.** The image runs as uid 10001. With a bind mount the server cannot create `/data/DeviceShelf`, logs `permission denied` and restart-loops — reproduced on the same VM. A named volume is seeded from the image and keeps its ownership, and comes up healthy. If a bind mount under AppData is preferred here, it needs a chown to 10001 somewhere in the install path; happy to switch if CasaOS has a hook for that.

The access token is generated on first start rather than pinned in the manifest, so no credential ships in a public app store. The `before_install` tip tells users how to read it from the CasaOS terminal.

DeviceShelf is proprietary, paid software: €59 once, no subscription, 7-day trial without a card. Flagging that plainly rather than leaving it for a reviewer to discover.