### PR TITLE
chore: update build appstore action

### DIFF
--- a/.github/actions/build-store-v2/action.yml
+++ b/.github/actions/build-store-v2/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     - name: Run upstream build action
       id: build
-      uses: IceWhaleTech/build-appstore-action@8e65e790b4e6da62dc0605e259b9219dd548a2ac
+      uses: IceWhaleTech/build-appstore-action@e3d9d9b28a473bd7ee82118621fb728559e4e5cb
       with:
         source: ${{ inputs.source }}
         output: ${{ inputs.output }}


### PR DESCRIPTION
Updates the pinned build-appstore-action revision used by build-store-v2.