### PR TITLE
fix: update workflow default base URL

### DIFF
--- a/.github/workflows/release-store.yml
+++ b/.github/workflows/release-store.yml
@@ -13,7 +13,7 @@ on:
       base_url:
         description: "Base URL used by the build action"
         required: false
-        default: "https://cdn.jsdelivr.net/gh/jerrykuku/ZimaOS-AppStore@gh-pages"
+        default: "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@gh-pages"
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       base_url:
         description: "Base URL used by the build action"
         required: false
-        default: "https://cdn.jsdelivr.net/gh/jerrykuku/ZimaOS-AppStore@gh-pages"
+        default: "https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@gh-pages"
 
 permissions:
   contents: read


### PR DESCRIPTION
Updates the default jsDelivr base URL used by manually dispatched build and release workflows.