### PR TITLE
Update Sonarr to 4.0.19

### DIFF
--- a/Apps/Sonarr/docker-compose.yml
+++ b/Apps/Sonarr/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       PGID: $PGID
       PUID: $PUID
       TZ: $TZ
-    image: linuxserver/sonarr:4.0.17
+    image: linuxserver/sonarr:4.0.19
     deploy:
       resources:
         reservations:
@@ -109,54 +109,54 @@ x-casaos:
     en_US: Sonarr
   index: /
   port_map: "8989"
-  version: "4.0.17"
-  update_at: "2026-05-09"
+  version: "4.0.19"
+  update_at: "2026-08-20"
   release_notes:
     en_US: |-
-      - Sonarr 4.0.17.2967 backports qBittorrent fixes to the v4 release line.
-      - The release is based on changes after v4.0.17.2953.
+      - Sonarr 4.0.19.2979 fixes qBittorrent Basic Auth and reuses authentication cookies.
+      - Updates FFprobe to 5.1.10. Docker users should update the container image rather than use the in-app updater.
     en_GB: |-
-      - Sonarr 4.0.17.2967 backports qBittorrent fixes to the v4 release line.
-      - The release is based on changes after v4.0.17.2953.
+      - Sonarr 4.0.19.2979 fixes qBittorrent Basic Auth and reuses authentication cookies.
+      - Updates FFprobe to 5.1.10. Docker users should update the container image rather than use the in-app updater.
     it_IT: |-
-      - Sonarr 4.0.17.2967 esegue il backport delle correzioni qBittorrent alla linea di rilascio v4.
-      - La versione si basa sulle modifiche successive a v4.0.17.2953.
+      - Sonarr 4.0.19.2979 corregge l'autenticazione di base di qBittorrent e riutilizza i cookie di autenticazione.
+      - Aggiorna FFprobe alla versione 5.1.10. Gli utenti Docker devono aggiornare l'immagine del contenitore anziché usare l'aggiornamento interno.
     nb_NO: |-
-      - Sonarr 4.0.17.2967 tilbakeporterer qBittorrent-fikser til v4 utgivelseslinjen.
-      - Utgivelsen er basert på endringer etter v4.0.17.2953.
+      - Sonarr 4.0.19.2979 retter grunnleggende autentisering for qBittorrent og gjenbruker autentiseringskapsler.
+      - Oppdaterer FFprobe til 5.1.10. Docker-brukere bør oppdatere beholderbildet i stedet for å bruke oppdateringen i appen.
     zh_CN: |-
-      - Sonarr 4.0.17.2967 将 qBittorrent 修复回移到 v4 发布线。
-      - 该版本基于 v4.0.17.2953 之后的变更。
+      - Sonarr 4.0.19.2979 修复了 qBittorrent 基本认证，并复用认证 Cookie。
+      - 将 FFprobe 更新至 5.1.10。Docker 用户应更新容器镜像，而不是使用应用内更新器。
     ja_JP: |-
-      - Sonarr 4.0.17.2967 は qBittorrent の修正を v4 リリースラインへバックポートします。
-      - このリリースは v4.0.17.2953 以降の変更に基づいています。
+      - Sonarr 4.0.19.2979 は qBittorrent の Basic 認証を修正し、認証 Cookie を再利用します。
+      - FFprobe を 5.1.10 に更新します。Docker ユーザーはアプリ内更新ではなくコンテナイメージを更新してください。
     ko_KR: |-
-      - Sonarr 4.0.17.2967은 qBittorrent 수정 사항을 v4 릴리스 라인으로 백포트합니다.
-      - 이 릴리스는 v4.0.17.2953 이후 변경 사항을 기반으로 합니다.
+      - Sonarr 4.0.19.2979는 qBittorrent 기본 인증을 수정하고 인증 쿠키를 재사용합니다.
+      - FFprobe를 5.1.10으로 업데이트합니다. Docker 사용자는 앱 내 업데이트 대신 컨테이너 이미지를 업데이트해야 합니다.
     fr_FR: |-
-      - Sonarr 4.0.17.2967 rétroporte des correctifs qBittorrent dans la ligne de release v4.
-      - Cette version est basée sur les changements après v4.0.17.2953.
+      - Sonarr 4.0.19.2979 corrige l'authentification Basic de qBittorrent et réutilise les cookies d'authentification.
+      - Met FFprobe à jour vers la version 5.1.10. Les utilisateurs Docker doivent mettre à jour l'image du conteneur plutôt que l'application elle-même.
     de_DE: |-
-      - Sonarr 4.0.17.2967 portiert qBittorrent-Korrekturen zurück in die v4-Release-Linie.
-      - Die Veröffentlichung basiert auf Änderungen nach v4.0.17.2953.
+      - Sonarr 4.0.19.2979 behebt die Basic-Authentifizierung für qBittorrent und verwendet Authentifizierungs-Cookies erneut.
+      - Aktualisiert FFprobe auf 5.1.10. Docker-Nutzer sollten das Container-Image statt des In-App-Updaters aktualisieren.
     sv_SE: |-
-      - Sonarr 4.0.17.2967 backportar qBittorrent-fixar till v4 release line.
-      - Utgivningen är baserad på ändringar efter v4.0.17.2953.
+      - Sonarr 4.0.19.2979 åtgärdar grundläggande autentisering för qBittorrent och återanvänder autentiseringscookies.
+      - Uppdaterar FFprobe till 5.1.10. Docker-användare bör uppdatera containeravbildningen i stället för att använda uppdateraren i appen.
     el_GR: |-
-      - Το Sonarr 4.0.17.2967 υποστηρίζει τις διορθώσεις qBittorrent στη γραμμή έκδοσης v4.
-      - Η κυκλοφορία βασίζεται σε αλλαγές μετά από v4.0.17.2953.
+      - Το Sonarr 4.0.19.2979 διορθώνει τον βασικό έλεγχο ταυτότητας του qBittorrent και επαναχρησιμοποιεί τα cookie ελέγχου ταυτότητας.
+      - Ενημερώνει το FFprobe στην έκδοση 5.1.10. Οι χρήστες Docker πρέπει να ενημερώσουν την εικόνα του κοντέινερ αντί να χρησιμοποιήσουν την ενημέρωση μέσα από την εφαρμογή.
     hr_HR: |-
-      - Sonarr 4.0.17.2967 vraća qBittorrent popravke na liniju izdanja v4.
-      - Izdanje se temelji na promjenama nakon v4.0.17.2953.
+      - Sonarr 4.0.19.2979 ispravlja osnovnu autentifikaciju za qBittorrent i ponovno koristi kolačiće za autentifikaciju.
+      - Ažurira FFprobe na 5.1.10. Korisnici Dockera trebaju ažurirati sliku spremnika umjesto ažuriranja unutar aplikacije.
     pt_PT: |-
-      - Sonarr 4.0.17.2967 faz backport das correções qBittorrent para a linha de lançamento v4.
-      - O lançamento é baseado em alterações posteriores a v4.0.17.2953.
+      - O Sonarr 4.0.19.2979 corrige a autenticação básica do qBittorrent e reutiliza cookies de autenticação.
+      - Atualiza o FFprobe para a versão 5.1.10. Os utilizadores de Docker devem atualizar a imagem do contentor em vez de usar o atualizador interno.
     ru_RU: |-
-      - Sonarr 4.0.17.2967 переносит исправления qBittorrent в линейку выпуска v4.
-      - Релиз основан на изменениях после v4.0.17.2953.
+      - Sonarr 4.0.19.2979 исправляет базовую аутентификацию qBittorrent и повторно использует файлы cookie аутентификации.
+      - Обновляет FFprobe до версии 5.1.10. Пользователям Docker следует обновлять образ контейнера, а не использовать встроенное обновление.
     tr_TR: |-
-      - Sonarr 4.0.17.2967, qBittorrent düzeltmelerini v4 sürüm satırına destekler.
-      - Sürüm, v4.0.17.2953 sonrasındaki değişikliklere dayanmaktadır.
+      - Sonarr 4.0.19.2979, qBittorrent temel kimlik doğrulamasını düzeltir ve kimlik doğrulama çerezlerini yeniden kullanır.
+      - FFprobe'u 5.1.10 sürümüne günceller. Docker kullanıcıları uygulama içi güncelleyici yerine konteyner görüntüsünü güncellemelidir.
   website: "https://sonarr.tv"
   repo: "https://github.com/Sonarr/Sonarr"
   support: "https://sonarr.tv/#support"


### PR DESCRIPTION
## Summary

- update the LinuxServer Sonarr image from `4.0.17` to `4.0.19`
- update the app catalog version and date
- refresh release notes for all 15 existing locales

## Release

The target image contains Sonarr `4.0.19.2979`. This release fixes qBittorrent Basic Auth, reuses authentication cookies, and updates FFprobe to 5.1.10.

No upstream release note documents a required change to the existing ports, environment variables, or volume mappings. The published image supports both `linux/amd64` and `linux/arm64`.

## Upgrade note

Sonarr can migrate data under `/config` during startup. Users should back up `/config` before upgrading. If a downgrade becomes necessary, restoring the pre-upgrade backup may be required; changing only the image tag may not be enough.

## Validation

- repository compose validator: 1 file checked, 0 errors, 0 warnings
- `git diff --check`
- `./scripts/build_dist.sh`: completed for 167 apps
- generated `dist/apps/org.icewhale.sonarr` metadata and compose files match version `4.0.19`
- Docker Hub manifest: verified `linux/amd64` and `linux/arm64`

Closes #906

Upstream release: https://github.com/Sonarr/Sonarr/releases/tag/v4.0.19.2979
