### PR TITLE
Update Prowlarr to 2.5.2

### DIFF
--- a/Apps/Prowlarr/docker-compose.yml
+++ b/Apps/Prowlarr/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       PGID: "1000"
       PUID: "1000"
       TZ: Europe/London
-    image: linuxserver/prowlarr:2.3.5
+    image: linuxserver/prowlarr:2.5.2
     deploy:
       resources:
         reservations:
@@ -87,69 +87,69 @@ x-casaos:
   title:
     en_US: Prowlarr
   port_map: "9696"
-  version: "2.3.5"
-  update_at: "2026-05-13"
+  version: "2.5.2"
+  update_at: "2026-08-20"
   release_notes:
     en_US: |-
-      - Prowlarr 2.3.5.5327 updates the browserlist database and improves HTTP file mappers.
-      - Fixes backup downloads when paths contain trailing slashes and PWA manifest behavior with URL bases.
-      - Docker users should update the container image rather than running the in-app updater inside an existing container.
+      - Prowlarr 2.5.2.5491 adds the DesiGaane and NZBIndex indexers and new IPTorrents sorting options.
+      - Improves size precision and fixes indexer category and parsing issues.
+      - Docker users should update the container image rather than use the in-app updater.
     en_GB: |-
-      - Prowlarr 2.3.5.5327 updates the browserlist database and improves HTTP file mappers.
-      - Fixes backup downloads when paths contain trailing slashes and PWA manifest behavior with URL bases.
-      - Docker users should update the container image rather than running the in-app updater inside an existing container.
+      - Prowlarr 2.5.2.5491 adds the DesiGaane and NZBIndex indexers and new IPTorrents sorting options.
+      - Improves size precision and fixes indexer category and parsing issues.
+      - Docker users should update the container image rather than use the in-app updater.
     it_IT: |-
-      - Prowlarr 2.3.5.5327 aggiorna il database dell'elenco dei browser e migliora i mappatori di file HTTP.
-      - Risolve i download di backup quando i percorsi contengono barre finali e il comportamento manifest PWA con basi URL.
-      - Gli utenti Docker devono aggiornare l'immagine del contenitore anziché eseguire il programma di aggiornamento in-app all'interno di un contenitore esistente.
+      - Prowlarr 2.5.2.5491 aggiunge gli indicizzatori DesiGaane e NZBIndex e nuove opzioni di ordinamento per IPTorrents.
+      - Migliora la precisione delle dimensioni e corregge problemi di categorie e analisi degli indicizzatori.
+      - Gli utenti Docker devono aggiornare l'immagine del contenitore anziché usare l'aggiornamento interno.
     nb_NO: |-
-      - Prowlarr 2.3.5.5327 oppdaterer nettleserlistedatabasen og forbedrer HTTP filtilordninger.
-      - Retter backup-nedlastinger når stier inneholder etterfølgende skråstreker og PWA manifest oppførsel med URL-baser.
-      - Docker-brukere bør oppdatere beholderbildet i stedet for å kjøre in-app-oppdateringen inne i en eksisterende beholder.
+      - Prowlarr 2.5.2.5491 legger til indeksererne DesiGaane og NZBIndex samt nye sorteringsvalg for IPTorrents.
+      - Forbedrer størrelsespresisjon og retter problemer med indekskategorier og parsing.
+      - Docker-brukere bør oppdatere beholderbildet i stedet for å bruke oppdateringen i appen.
     zh_CN: |-
-      - Prowlarr 2.3.5.5327 更新了 browserlist database，并改进了 HTTP file mappers。
-      - 修复了路径带尾随斜杠时的 backup downloads，以及带 URL bases 时的 PWA manifest 行为。
-      - Docker 用户应更新容器镜像，而不是在现有容器内运行应用内 updater。
+      - Prowlarr 2.5.2.5491 新增 DesiGaane 和 NZBIndex 索引器，以及 IPTorrents 排序选项。
+      - 提高大小解析精度，并修复索引器分类和解析问题。
+      - Docker 用户应更新容器镜像，而不是使用应用内更新器。
     ja_JP: |-
-      - Prowlarr 2.3.5.5327 は browserlist database を更新し、HTTP file mappers を改善します。
-      - パス末尾にスラッシュがある場合の backup downloads と、URL bases 使用時の PWA manifest 動作を修正します。
-      - Docker ユーザーは既存コンテナ内のアプリ内 updater ではなく、コンテナイメージを更新してください。
+      - Prowlarr 2.5.2.5491 は DesiGaane と NZBIndex インデクサー、および IPTorrents の新しい並べ替えオプションを追加します。
+      - サイズ精度を改善し、インデクサーのカテゴリと解析の問題を修正します。
+      - Docker ユーザーはアプリ内更新ではなくコンテナイメージを更新してください。
     ko_KR: |-
-      - Prowlarr 2.3.5.5327은 browserlist database를 업데이트하고 HTTP file mappers를 개선합니다.
-      - 경로에 trailing slash가 있을 때의 backup downloads와 URL bases 사용 시 PWA manifest 동작을 수정합니다.
-      - Docker 사용자는 기존 컨테이너 안에서 인앱 updater를 실행하지 말고 컨테이너 이미지를 업데이트해야 합니다.
+      - Prowlarr 2.5.2.5491은 DesiGaane 및 NZBIndex 인덱서와 새로운 IPTorrents 정렬 옵션을 추가합니다.
+      - 크기 정밀도를 개선하고 인덱서 카테고리 및 파싱 문제를 수정합니다.
+      - Docker 사용자는 앱 내 업데이트 대신 컨테이너 이미지를 업데이트해야 합니다.
     fr_FR: |-
-      - Prowlarr 2.3.5.5327 met à jour la browserlist database et améliore les HTTP file mappers.
-      - Corrige les téléchargements de sauvegarde quand les chemins ont une barre finale et le comportement du PWA manifest avec des URL bases.
-      - Les utilisateurs Docker doivent mettre à jour l'image du conteneur plutôt que d'exécuter l'updater intégré dans un conteneur existant.
+      - Prowlarr 2.5.2.5491 ajoute les indexeurs DesiGaane et NZBIndex ainsi que de nouvelles options de tri IPTorrents.
+      - Améliore la précision des tailles et corrige des problèmes de catégories et d'analyse des indexeurs.
+      - Les utilisateurs Docker doivent mettre à jour l'image du conteneur plutôt que l'application elle-même.
     de_DE: |-
-      - Prowlarr 2.3.5.5327 aktualisiert die browserlist database und verbessert HTTP file mappers.
-      - Behebt Backup-Downloads bei Pfaden mit abschließendem Slash sowie PWA-Manifest-Verhalten mit URL bases.
-      - Docker-Nutzer sollten das Container-Image aktualisieren, statt den In-App-Updater im bestehenden Container auszuführen.
+      - Prowlarr 2.5.2.5491 fügt die Indexer DesiGaane und NZBIndex sowie neue IPTorrents-Sortieroptionen hinzu.
+      - Verbessert die Größengenauigkeit und behebt Probleme bei Indexer-Kategorien und der Analyse.
+      - Docker-Nutzer sollten das Container-Image statt des In-App-Updaters aktualisieren.
     sv_SE: |-
-      - Prowlarr 2.3.5.5327 uppdaterar webbläsarlistdatabasen och förbättrar HTTP filmappare.
-      - Fixar backup-nedladdningar när sökvägar innehåller efterföljande snedstreck och PWA manifest beteende med URL baser.
-      - Docker-användare bör uppdatera behållarbilden istället för att köra in-app-uppdateringsprogrammet i en befintlig behållare.
+      - Prowlarr 2.5.2.5491 lägger till indexerarna DesiGaane och NZBIndex samt nya sorteringsalternativ för IPTorrents.
+      - Förbättrar storleksprecisionen och åtgärdar problem med indexerkategorier och tolkning.
+      - Docker-användare bör uppdatera containeravbildningen i stället för att använda uppdateraren i appen.
     el_GR: |-
-      - Το Prowlarr 2.3.5.5327 ενημερώνει τη βάση δεδομένων της λίστας περιήγησης και βελτιώνει τις αντιστοιχίσεις αρχείων HTTP.
-      - Διορθώνει τις λήψεις αντιγράφων ασφαλείας όταν οι διαδρομές περιέχουν τελικές κάθετες και PWA εμφανή συμπεριφορά με URL βάσεις.
-      - Οι χρήστες Docker θα πρέπει να ενημερώσουν την εικόνα του κοντέινερ αντί να εκτελούν το πρόγραμμα ενημέρωσης in-app μέσα σε ένα υπάρχον κοντέινερ.
+      - Το Prowlarr 2.5.2.5491 προσθέτει τα ευρετήρια DesiGaane και NZBIndex και νέες επιλογές ταξινόμησης για το IPTorrents.
+      - Βελτιώνει την ακρίβεια μεγέθους και διορθώνει προβλήματα κατηγοριών και ανάλυσης ευρετηρίων.
+      - Οι χρήστες Docker πρέπει να ενημερώσουν την εικόνα του κοντέινερ αντί να χρησιμοποιήσουν την ενημέρωση μέσα από την εφαρμογή.
     hr_HR: |-
-      - Prowlarr 2.3.5.5327 ažurira bazu podataka popisa preglednika i poboljšava mapere datoteka HTTP.
-      - Popravlja sigurnosna preuzimanja kada staze sadrže kose crte na kraju i ponašanje manifesta PWA s bazama URL.
-      - Korisnici Docker trebali bi ažurirati sliku spremnika umjesto pokretanja programa za ažuriranje in-app unutar postojećeg spremnika.
+      - Prowlarr 2.5.2.5491 dodaje indeksere DesiGaane i NZBIndex te nove mogućnosti sortiranja za IPTorrents.
+      - Poboljšava preciznost veličine i ispravlja probleme s kategorijama i raščlanjivanjem indeksera.
+      - Korisnici Dockera trebaju ažurirati sliku spremnika umjesto ažuriranja unutar aplikacije.
     pt_PT: |-
-      - Prowlarr 2.3.5.5327 atualiza a base de dados da lista de navegadores e melhora os mapeadores de ficheiros HTTP.
-      - Corrige os downloads de cópias de segurança quando os caminhos contêm barras finais e o comportamento de manifesto PWA com bases URL.
-      - Os utilizadores de Docker devem atualizar a imagem do contentor em vez de executar o atualizador in-app dentro de um contentor existente.
+      - O Prowlarr 2.5.2.5491 adiciona os indexadores DesiGaane e NZBIndex e novas opções de ordenação do IPTorrents.
+      - Melhora a precisão dos tamanhos e corrige problemas de categorias e análise dos indexadores.
+      - Os utilizadores de Docker devem atualizar a imagem do contentor em vez de usar o atualizador interno.
     ru_RU: |-
-      - Prowlarr 2.3.5.5327 обновляет базу данных списка браузеров и улучшает средства сопоставления файлов HTTP.
-      - Исправлена ​​загрузка резервных копий, когда пути содержат косые черты и поведение манифеста PWA с базами URL.
-      - Пользователям Docker следует обновить образ контейнера, а не запускать программу обновления in-app внутри существующего контейнера.
+      - Prowlarr 2.5.2.5491 добавляет индексаторы DesiGaane и NZBIndex, а также новые параметры сортировки IPTorrents.
+      - Повышает точность размеров и исправляет проблемы категорий и анализа индексаторов.
+      - Пользователям Docker следует обновлять образ контейнера, а не использовать встроенное обновление.
     tr_TR: |-
-      - Prowlarr 2.3.5.5327 tarayıcı listesi veritabanını günceller ve HTTP dosya eşleyicilerini geliştirir.
-      - Yollar eğik çizgiler içerdiğinde ve URL tabanlarıyla PWA bildirim davranışını içerdiğinde yedekleme indirmelerini düzeltir.
-      - Docker kullanıcıları, in-app güncelleyicisini mevcut bir kapsayıcı içinde çalıştırmak yerine kapsayıcı görüntüsünü güncellemelidir.
+      - Prowlarr 2.5.2.5491, DesiGaane ve NZBIndex indeksleyicilerini ve yeni IPTorrents sıralama seçeneklerini ekler.
+      - Boyut hassasiyetini iyileştirir ve indeksleyici kategori ve ayrıştırma sorunlarını düzeltir.
+      - Docker kullanıcıları uygulama içi güncelleyici yerine konteyner görüntüsünü güncellemelidir.
   website: "https://prowlarr.com"
   repo: "https://github.com/Prowlarr/Prowlarr"
   support: "https://wiki.servarr.com/prowlarr/troubleshooting"


### PR DESCRIPTION
## Summary

- update the LinuxServer Prowlarr image from `2.3.5` to `2.5.2`
- update the app catalog version and date
- refresh release notes for all 15 existing locales

## Release

The target image contains Prowlarr `2.5.2.5491`. This release adds the DesiGaane and NZBIndex indexers, adds IPTorrents sorting options, improves size precision, and fixes several indexer category and parsing issues.

No upstream release note documents a required change to the existing port, environment variables, or `/config` mapping. The published image supports both `linux/amd64` and `linux/arm64`.

## Upgrade note

Prowlarr can migrate data under `/config` during startup. Users should back up `/config` before upgrading. If a downgrade becomes necessary, restoring the pre-upgrade backup may be required; changing only the image tag may not be enough.

## Validation

- repository compose validator: 1 file checked, 0 errors, 0 warnings
- `git diff --check`
- `./scripts/build_dist.sh`: completed for 167 apps
- generated `dist/apps/org.icewhale.prowlarr` metadata and compose files match version `2.5.2`
- Docker Hub manifest: verified `linux/amd64` and `linux/arm64`

Closes #904

Upstream release: https://github.com/Prowlarr/Prowlarr/releases/tag/v2.5.2.5491
