### PR TITLE
Change published ports to default DNS port 53

### DIFF
--- a/Apps/AdGuardHome/docker-compose.yml
+++ b/Apps/AdGuardHome/docker-compose.yml
@@ -9,10 +9,10 @@ services:
     network_mode: bridge
     ports:
       - target: 53
-        published: "531"
+        published: "53"
         protocol: tcp
       - target: 53
-        published: "531"
+        published: "53"
         protocol: udp
       - target: 3000
         published: "3001"


### PR DESCRIPTION
Updated published ports for AdGuardHome service to use default DNS port 53.