### PR TITLE
docs: add Service Dash to the third-party store list

### DIFF
--- a/docs/resources/recommended-third-party-stores.md
+++ b/docs/resources/recommended-third-party-stores.md
@@ -20,6 +20,14 @@ Community store sources for ZimaOS. Copy a source link, then import it in ZimaOS
   repo-url="https://github.com/bigbeartechworld/big-bear-casaos/"
 />
 
+<StoreSourceCard
+  title="Service Dash"
+  summary="Homelab dashboard for Uptime Kuma: every service's local and public URL on one card, plus live host metrics."
+  url="https://cdn.jsdelivr.net/gh/cvaghela/service-dash@gh-pages/store.json"
+  maintainer="cvaghela"
+  repo-url="https://github.com/cvaghela/service-dash"
+/>
+
 ## About this list
 
 - This is a community discovery page, not a formal endorsement list.

--- a/docs/zh/resources/recommended-third-party-stores.md
+++ b/docs/zh/resources/recommended-third-party-stores.md
@@ -28,6 +28,18 @@
   repo-url="https://github.com/bigbeartechworld/big-bear-casaos/"
 />
 
+<StoreSourceCard
+  title="Service Dash"
+  summary="Uptime Kuma 家庭实验室仪表板：每个服务的本地与公网地址同卡显示，并附主机实时指标。"
+  url="https://cdn.jsdelivr.net/gh/cvaghela/service-dash@gh-pages/store.json"
+  maintainer="cvaghela"
+  copy-label="复制链接"
+  copied-label="已复制"
+  open-label="打开链接"
+  repo-label="GitHub 仓库"
+  repo-url="https://github.com/cvaghela/service-dash"
+/>
+
 ## 页面说明
 
 - 这是一个社区发现页，不是正式背书列表。


### PR DESCRIPTION
**What this is:** a docs change.

Adds the [Service Dash](https://github.com/cvaghela/service-dash) store source to *Awesome Third-party Stores*.

Service Dash is a homelab dashboard that shows every service's **local and public URL on one card**, alongside live host CPU, RAM, storage and network metrics. It reads monitors from Uptime Kuma and bundles a Netdata Agent. The store is built with this project's own `IceWhaleTech/build-appstore-action` and published to `gh-pages`.

Source link:

```
https://cdn.jsdelivr.net/gh/cvaghela/service-dash@gh-pages/store.json
```

## What changed

Two files, one card each, inserted after the existing entries:

- `docs/resources/recommended-third-party-stores.md`
- `docs/zh/resources/recommended-third-party-stores.md`

The Chinese card includes the `copy-label` / `copied-label` / `open-label` / `repo-label` props the other cards on that page carry, so its buttons render in Chinese rather than falling back to English.

## Validation

The store source resolves and is live — every file a client fetches returns 200:

| Path | |
|---|---|
| `store.json` | 200 |
| `index.json` | 200 |
| `apps/…/meta.json` | 200 |
| `apps/…/docker-compose.yml` | 200 |
| `apps/…/docker-compose.amd64.yml` | 200 |
| assets (icon, thumbnail, 3 screenshots) | 200 |

I have also opened #1024 proposing the app for the official store. These are independent — this one stands on its own if that is not a fit.