### PR TITLE
fix(Clumoove): complete x-casaos metadata

### DIFF
--- a/Apps/Clumoove/docker-compose.yml
+++ b/Apps/Clumoove/docker-compose.yml
@@ -113,6 +113,9 @@ x-casaos:
   author: Marcel Meyer
   developer: Marcel Meyer
   icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Clumoove/icon.svg
+  screenshot_link:
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Clumoove/screenshot-1.png
+    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Clumoove/screenshot-2.png
   thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Clumoove/thumbnail.png
   title:
     en_US: Clumoove
@@ -148,3 +151,18 @@ x-casaos:
   port_map: "8380"
   scheme: http
   index: /
+  version: "0.16.0"
+  update_at: "2026-08-26"
+  release_notes:
+    en_US: |-
+      - v0.16.0 introduces incremental, block-deduplicated snapshot backups, two-phase restore previews, retention policies, integrity checks, and dedicated backup dashboards.
+      - It improves multi-provider checksum verification, OAuth and SMTP security, queue and sync reliability, and HiDrive and local storage handling.
+      - It fixes WebDAV conflicts, Immich migration behavior, sync browse credentials, UI and modal stability, and Linux build compatibility.
+    de_DE: |-
+      - v0.16.0 führt inkrementelle Snapshot-Backups mit blockbasierter Deduplizierung, zweistufige Wiederherstellungsvorschauen, Aufbewahrungsrichtlinien, Integritätsprüfungen und eigene Backup-Dashboards ein.
+      - Verbessert wurden die Prüfsummenverifikation zwischen Anbietern, die OAuth- und SMTP-Sicherheit, die Queue- und Sync-Zuverlässigkeit sowie HiDrive und lokaler Speicher.
+      - Behoben wurden WebDAV-Konflikte, das Immich-Migrationsverhalten, Anmeldedaten beim Sync-Browsing, die UI- und Modal-Stabilität sowie die Linux-Build-Kompatibilität.
+  website: "https://clumoove.com"
+  repo: "https://github.com/xXRoxXeRXx/clumoove"
+  support: "https://github.com/xXRoxXeRXx/clumoove/issues"
+  docs: "https://docs.clumoove.com"


### PR DESCRIPTION
## What changed

- add the available Clumoove screenshots to `screenshot_link`
- add v0.16.0 version metadata, release date, and English/German release notes
- add the official website, repository, support, and documentation links

## Validation

- `python3 .github/actions/validate-compose/scripts/validate_compose.py --app-path Clumoove --report-json /tmp/clumoove-validation.json`
- YAML language-server validation
- `git diff --check`
