### PR TITLE
Add SubsiMail

### DIFF
--- a/Apps/SubsiMail/docker-compose.yml
+++ b/Apps/SubsiMail/docker-compose.yml
@@ -1,0 +1,55 @@
+name: subsimail
+services:
+  web:
+    image: subsimail/subsimail:2.0.0@sha256:aa825794bd2a171a2f663cdcc9ea56943a90b2200c4e94459f5a8dcc7523edc5
+    container_name: subsimail
+    restart: unless-stopped
+    volumes:
+      - /DATA/AppData/$AppID/data:/app/data
+    environment:
+      DATABASE_URL: sqlite:///app/data/subsimail.db
+    ports:
+      - target: 3000
+        published: "3860"
+        protocol: tcp
+x-casaos:
+  id: com.subsimail.app
+  main: web
+  index: /
+  port_map: "3860"
+  scheme: http
+  icon: https://subsimail.com/static/apple-touch-icon.png
+  title:
+    en_US: SubsiMail
+  tagline:
+    en_US: Self-hosted cold email outreach that runs on your own server
+  description:
+    en_US: |-
+      Note: after install, SubsiMail needs a free license token to activate. Sign up at subsimail.com (no credit card) and either paste the token it gives you, or use "Connect your account" to fetch it automatically — both happen from the setup screen in your browser. The first connected mailbox is free forever.
+
+      SubsiMail is a self-hosted cold email sequencing platform. Prospect lists, templates, connected inboxes, and all campaign data live in your own SQLite database on your own server, never in a third party's cloud.
+
+      It's built as a self-hosted alternative to tools like Instantly, Smartlead, lemlist, and Apollo, with flat, per-inbox pricing instead of per-seat fees, full data ownership and export, no content review of what you send, and no third-party access to your contacts or campaigns.
+
+      Key features:
+      - Connect Gmail, Outlook, or any SMTP/IMAP inbox
+      - Multi-step sequences with merge fields and reply detection
+      - Per-user roles (admin/manager/view-only) and a full audit trail
+      - A REST API with personal API keys for your own integrations
+  thumbnail: ""
+  screenshot_link:
+    - https://subsimail.com/static/img/marketing/dashboard-hero.png
+  author: SubsiMail
+  developer: SubsiMail
+  category: Productivity
+  architectures:
+    - amd64
+    - arm64
+  version: "2.0.0"
+  update_at: "2026-09-04"
+  release_notes:
+    en_US: Initial CasaOS package.
+  website: "https://subsimail.com"
+  repo: "https://subsimail.com"
+  support: "https://subsimail.com/docs"
+  docs: "https://subsimail.com/docs"


### PR DESCRIPTION
## App

**SubsiMail** v2.0.0 — self-hosted cold email sequencing platform. Prospect lists, templates, connected inboxes, and campaign data are stored in the user's own SQLite database on their own server, not a third-party SaaS. Positioned as a self-hosted alternative to Instantly / Smartlead / lemlist / Apollo, with flat per-inbox pricing instead of per-seat fees.

- Website: https://subsimail.com
- Docs/support: https://subsimail.com/docs

## Image source

- `docker.io/subsimail/subsimail`, tag `2.0.0`, pinned to the multi-arch manifest-list digest.
- Verified `linux/amd64` and `linux/arm64` both present via `docker buildx imagetools inspect subsimail/subsimail:2.0.0`.

## Notable setup behavior

- **The app requires a free license token from subsimail.com before it's usable**, even on the free tier (first connected mailbox is free forever, no card required). From the in-browser setup screen, the user either pastes a token or uses a "Connect your account" button that goes through subsimail.com OAuth. Called out at the top of the `x-casaos.description` so it isn't a surprise mid-install.
- No default username/password — account creation happens in-browser after the license step.
- Single `web` service, SQLite data persisted under `/DATA/AppData/$AppID/data`, migrations run automatically and idempotently on startup.
- No host access, no privileged mode, no extra permissions needed.
- `repo`/`website`/`docs` all point at subsimail.com since the application source is closed — there's no separate public source repo to link.

## Testing performed

- Built and pushed the multi-arch image myself (amd64 native + arm64 via buildx/QEMU), confirmed both platforms resolve under one digest.
- Ran the arm64 image directly (`docker run --platform linux/arm64`), confirmed it boots, prints its normal startup banner, and runs its embedded SQLite migrations without error.
- Validated the compose file loads as expected YAML with the exact `x-casaos` field shapes from the spec doc (locale-keyed `title`/`tagline`/`description`, quoted `port_map`, long-form `ports` syntax). Wasn't able to run the repo's own `docker compose config -q` / `build_dist.sh` locally (no `docker compose` plugin in this environment) — happy to fix anything CI flags.
- Have not yet run a full install through a live CasaOS/ZimaOS instance — happy to do that as a follow-up if a maintainer wants it before merge.

## Assets for review

Logo: https://subsimail.com/static/apple-touch-icon.png

Screenshot: https://subsimail.com/static/img/marketing/dashboard-hero.png
